### PR TITLE
Add app protocol to ignored classes

### DIFF
--- a/AutomaticBugs/BasicData.gd
+++ b/AutomaticBugs/BasicData.gd
@@ -200,6 +200,7 @@ var disabled_classes: Array = [
 	###
 	### Crashes, Freezes
 	###
+	"AppProtocol", # AppProtocol singleton was recreated by script, should not instance it.
 	"ProjectSettings",  # Don't mess with project settings, because they can broke entire your workflow
 	"EditorSettings",  # Also don't mess with editor settings
 	"GDScript",  # Broke script


### PR DESCRIPTION
This is work for a PR https://github.com/godotengine/godot/pull/63631

It was instancing a singleton class which should not be instanced.

Example:
https://github.com/godotengine/godot/runs/7619011750?check_suite_focus=true

If there is another approach let me know.