### PR TITLE
Add `open_inputs` to the list of exceptions

### DIFF
--- a/AutomaticBugs/BasicData.gd
+++ b/AutomaticBugs/BasicData.gd
@@ -26,6 +26,7 @@ var function_exceptions: Array = [
 	"getvar",  #GH 46019
 	"get_available_chars",  #GH 46118
 	"open_midi_inputs",  #GH 46183
+	"open_inputs",  #GH 86713
 	"set_icon",  #GH 46189
 	"get_latin_keyboard_variant",  #GH  TODO Memory Leak
 	"set_editor_hint",  #GH 46252


### PR DESCRIPTION
Required for https://github.com/godotengine/godot/pull/86713 to be merged.

All tests pass with the original name. But with "open_inputs" they do not.