### PR TITLE
Add `open_inputs` to the list of exceptions

### DIFF
--- a/AutomaticBugs/BasicData.gd
+++ b/AutomaticBugs/BasicData.gd
@@ -29,6 +29,7 @@ var function_exceptions: Array = [
 	"set_texture",  #46828
 	"compress_from_channels",  # Image
 	"open_midi_inputs",  #52821
+	"open_inputs",  #86713
 	"load_threaded_request",  #46762
 	"bake_navigation_mesh",  # TODO too hard to find for now
 	"set_is_setup",  # Just don't use, in SkeletonModification crashes


### PR DESCRIPTION
Required for https://github.com/godotengine/godot/pull/86713 to be merged.

All tests pass with the original name. But with "open_inputs" they do not.

This was previously [accidentally pushed to the 3.x branch](https://github.com/godotengine/regression-test-project/pull/80).